### PR TITLE
Disallow updating a travelnet for players who cannot use it

### DIFF
--- a/locked_travelnet.lua
+++ b/locked_travelnet.lua
@@ -87,6 +87,9 @@ minetest.register_node("locked_travelnet:travelnet", {
     end,
 
     on_punch          = function(pos, node, puncher)
+                          if not locks:lock_allow_use( pos, puncher ) then
+                              return false
+                          end
                           travelnet.update_formspec(pos, puncher:get_player_name())
     end,
 


### PR DESCRIPTION
Fixes BLS issue 121 https://github.com/BlockySurvival/issue-tracker/issues/121
Or issue #4 in this repo

This fixes the issue by simply disallowing anyone who cannot use the travelnet from interacting with it by punching it.

This still allows them to access it with a password if they right click it, which all works as expected.

The one downside to this is that owners cannot update their travelnet of they are not holding a key(ring), but I see this as a minor inconvenience.

I think disallowing non-allowed users to update the travelnet is probably for the best anyways, they don't need to because they cannot travel to any of the places anyway, and by updating it they may actually cause an inconvenience for the actual owner.

Either way this is the quickest solution to a security issue, I hope it gets merged soon